### PR TITLE
Fixed minor typo in the 'How to read' section

### DIFF
--- a/doc/.NETMemoryPerformanceAnalysis.md
+++ b/doc/.NETMemoryPerformanceAnalysis.md
@@ -16,7 +16,7 @@ This is a long document but you don’t need to read all of it; you also don’t
 
 :small_blue_diamond: If you are completely new to perf work, I would recommend to start at the beginning.
 
-:small_blue_diamond: For someone who's already comfort doing perf work in general but wishes to increase their knowledge in managed memory related topics, they can skip the beginning and go directly to the [Fundamentals](#Memory-Fundamentals) section. 
+:small_blue_diamond: For someone who's already comfortable doing perf work in general but wishes to increase their knowledge in managed memory related topics, they can skip the beginning and go directly to the [Fundamentals](#Memory-Fundamentals) section. 
 
 :small_blue_diamond: If you are not very experienced and doing a one off analysis, you could jump to the [Know when to worry](#Know-when-to-worry) section, read from there, and refer back to the [Fundamentals](#Memory-Fundamentals) section for specific topics if needed. 
 


### PR DESCRIPTION
Just a simple typo fix: comfort->comfortable