### PR TITLE
Formatted word “induced” as code

### DIFF
--- a/doc/.NETMemoryPerformanceAnalysis.md
+++ b/doc/.NETMemoryPerformanceAnalysis.md
@@ -1010,7 +1010,7 @@ Out of these reasons the most common you’d see (and want to see) is *AllocSmal
 
 And as we know that triggering frequent full GCs is usually a recipe for performance problems. Other trigger reasons due to allocations are *OutOfSpaceSOH* and *OutOfSpaceLOH* – you see these much less frequently than AllocSmall and AllocLarge – these are for when you are close to physical space limit (e.g., if we are getting close to the end of the ephemeral segment). 
 
-The ones that almost always raise a red flag are the `Induced*` ones as those mean some code actually is triggering GCs on its own. We have a GCTriggered event specifically for finding out what code triggered a GC with its callstack. You can collect a very lightweight trace with just the GC informational level with stack and minimal kernel events:
+The ones that almost always raise a red flag are the `Induced` ones as those mean some code actually is triggering GCs on its own. We have a GCTriggered event specifically for finding out what code triggered a GC with its callstack. You can collect a very lightweight trace with just the GC informational level with stack and minimal kernel events:
 
 `PerfView.exe /nogui /accepteula /KernelEvents=Process+Thread+ImageLoad /ClrEvents:GC+Stack /ClrEventLevel=Informational /BufferSize:3000 /CircularMB:3000 collect`
 

--- a/doc/.NETMemoryPerformanceAnalysis.md
+++ b/doc/.NETMemoryPerformanceAnalysis.md
@@ -1010,7 +1010,7 @@ Out of these reasons the most common you’d see (and want to see) is *AllocSmal
 
 And as we know that triggering frequent full GCs is usually a recipe for performance problems. Other trigger reasons due to allocations are *OutOfSpaceSOH* and *OutOfSpaceLOH* – you see these much less frequently than AllocSmall and AllocLarge – these are for when you are close to physical space limit (e.g., if we are getting close to the end of the ephemeral segment). 
 
-The ones that almost always raise a red flag are the induced ones as those mean some code actually is triggering GCs on its own. We have a GCTriggered event specifically for finding out what code triggered a GC with its callstack. You can collect a very lightweight trace with just the GC informational level with stack and minimal kernel events:
+The ones that almost always raise a red flag are the `Induced*` ones as those mean some code actually is triggering GCs on its own. We have a GCTriggered event specifically for finding out what code triggered a GC with its callstack. You can collect a very lightweight trace with just the GC informational level with stack and minimal kernel events:
 
 `PerfView.exe /nogui /accepteula /KernelEvents=Process+Thread+ImageLoad /ClrEvents:GC+Stack /ClrEventLevel=Informational /BufferSize:3000 /CircularMB:3000 collect`
 


### PR DESCRIPTION
While I was reading a doc, I caught myself that I missed the link between trigger reasons and the paragraph about induced GC, because I didn’t realized that word induced refers to enumeration. This is a very tiny change and it is quite subjective, so feel free to ignore it if it doesn’t seem reasonable :)