### PR TITLE
Fix typo in StopOnBGCFinalPauseOverMSec documentation

### DIFF
--- a/doc/.NETMemoryPerformanceAnalysis.md
+++ b/doc/.NETMemoryPerformanceAnalysis.md
@@ -1205,7 +1205,7 @@ There are 3 GC specific stop triggers –
 | --------------------------- | ------------------------------------------------------------ |
 | StopOnGCOverMsec            | trigger if the time between  GC/Start and GC/Stop is over this value, and it's not a BGC |
 | StopOnGCSuspendOverMSec     | trigger if the time between  GC/SuspendEEStart and GC/SuspendEEStop is over this value |
-| StopOnBGCFinalPauseOverMSec | trigger if the time between  GC/SuspendEEStart (with Reason SuspendForGCPrep) and GC/SuspendEEStop is over  this value |
+| StopOnBGCFinalPauseOverMSec | trigger if the time between  GC/SuspendEEStart (with Reason SuspendForGCPrep) and GC/RestartEEStop is over  this value |
 
 The commandlines I usually use with /StopOnGCOverMSec and /StopOnBGCFinalPauseOverMSec are –
 


### PR DESCRIPTION
I noticed that the doc for `StopOnBGCFinalPauseOverMSec` says the stop event is `SuspendEEStop`, but looking at the source code in PerfView I can see it is `RestartEEStop` which is in line with the analysis done in the table just above this one, so I think it's a typo.